### PR TITLE
Make MiniLoop compatible with IO::Async::Loop

### DIFF
--- a/lib/Object/Remote.pm
+++ b/lib/Object/Remote.pm
@@ -32,7 +32,10 @@ sub connect {
 }
 
 sub current_loop {
-  our $Current_Loop ||= Object::Remote::MiniLoop->new
+  our $Current_Loop ||=
+    (eval { require IO::Async::Loop; 1 })
+      ? IO::Async::Loop->new
+      : Object::Remote::MiniLoop->new
 }
 
 1;

--- a/lib/Object/Remote/Connection.pm
+++ b/lib/Object/Remote/Connection.pm
@@ -59,7 +59,7 @@ has read_channel => (
 );
 
 has on_close => (
-  is => 'rw', default => sub { $_[0]->_install_future_handlers(Future->new) },
+  is => 'rw', default => sub { $_[0]->_install_future_handlers(Object::Remote->current_loop->new_future) },
   trigger => sub {
     log_trace { "Installing handlers into future via trigger" };
     $_[0]->_install_future_handlers($_[1])
@@ -326,7 +326,7 @@ sub send_free {
 sub send {
   my ($self, $type, @call) = @_;
 
-  my $future = Future->new;
+  my $future = Object::Remote->current_loop->new_future;
   my $remote = $self->remote_objects_by_id->{$call[0]};
 
   unshift @call, $type => $self->_local_object_to_id($future);

--- a/lib/Object/Remote/ConnectionServer.pm
+++ b/lib/Object/Remote/ConnectionServer.pm
@@ -54,7 +54,7 @@ sub _listen_ready {
   my $new = $fh->accept or die "Couldn't accept: $!";
   log_trace { "Setting file handle non-blocking" };
   $new->blocking(0);
-  my $f = Future->new;
+  my $f = Object::Remote->current_loop->new_future;
   log_trace { "Creating a new connection with the remote node" };
   my $c = use_module('Object::Remote::Connection')->new(
     receive_from_fh => $new,

--- a/lib/Object/Remote/Future.pm
+++ b/lib/Object/Remote/Future.pm
@@ -18,37 +18,15 @@ sub future (&;$) {
   await_future($f);
 }
 
-our @await;
-
 sub await_future {
   my $f = shift;
-  log_trace { my $ir = $f->is_ready; "await_future() invoked; is_ready: $ir" };
-  return $f if $f->is_ready;
-  require Object::Remote;
-  my $loop = Object::Remote->current_loop;
-  {
-    local @await = (@await, $f);
-    $f->on_ready(sub {
-      log_trace { my $l = @await; "future has become ready, length of \@await: '$l'" };
-      if ($f == $await[-1]) {
-        log_trace { "This future is not waiting on anything so calling stop on the run loop" };
-        $loop->stop;
-      }
-    });
-    log_trace { "Starting run loop for newly created future" };
-    $loop->run;
-  }
-  if (@await and $await[-1]->is_ready) {
-    log_trace { "Last future in await list was ready, stopping run loop" };
-    $loop->stop;
-  }
-  log_trace { "await_future() returning" };
+  Object::Remote->current_loop->await($f);
   return wantarray ? $f->get : ($f->get)[0];
 }
 
 sub await_all {
   log_trace { my $l = @_; "await_all() invoked with '$l' futures to wait on" };
-  await_future(Object::Remote->current_loop->wait_all(@_));
+  Object::Remote->current_loop->await_all(@_);
   map $_->get, @_;
 }
 

--- a/lib/Object/Remote/MiniLoop.pm
+++ b/lib/Object/Remote/MiniLoop.pm
@@ -242,4 +242,12 @@ sub run {
   return;
 }
 
+sub new_future {
+    return Future->new;
+}
+
+sub await_all {
+    return Future->await_all(@_);
+}
+
 1;

--- a/lib/Object/Remote/MiniLoop.pm
+++ b/lib/Object/Remote/MiniLoop.pm
@@ -246,8 +246,38 @@ sub new_future {
     return Future->new;
 }
 
+our @await;
+
+sub await {
+  my ($self, $f) = @_;
+  log_trace { my $ir = $f->is_ready; "await_future() invoked; is_ready: $ir" };
+  return $f if $f->is_ready;
+  require Object::Remote;
+  my $loop = Object::Remote->current_loop;
+  {
+    local @await = (@await, $f);
+    $f->on_ready(sub {
+      log_trace { my $l = @await; "future has become ready, length of \@await: '$l'" };
+      if ($f == $await[-1]) {
+        log_trace { "This future is not waiting on anything so calling stop on the run loop" };
+        $loop->stop;
+      }
+    });
+    log_trace { "Starting run loop for newly created future" };
+    $loop->run;
+  }
+  if (@await and $await[-1]->is_ready) {
+    log_trace { "Last future in await list was ready, stopping run loop" };
+    $loop->stop;
+  }
+  log_trace { "await_future() returning" };
+  return $f;
+}
+
 sub await_all {
-    return Future->await_all(@_);
+    my $self = shift;
+    $self->await(Future->wait_all(@_));
+    return;
 }
 
 1;


### PR DESCRIPTION
This allows plugging an instance of IO::Async::Loop into $Object::Remote::Current_Loop, resulting in Object::Remote using futures that are Future::AsyncAwait enabled.

E.g. given a remote object instance `$l` with an "uptime" method which returns the result of an "uptime" system utility invocation, the following will work:

```perl
my $f = $l->start::uptime();
say await $f;
```

